### PR TITLE
fix issue with block number loading

### DIFF
--- a/packages/evm-rpc-canister-types/src/lib.rs
+++ b/packages/evm-rpc-canister-types/src/lib.rs
@@ -178,14 +178,15 @@ pub enum MultiFeeHistoryResult {
 #[derive(CandidType, Deserialize, Debug, Clone)]
 pub struct Block {
     pub miner: String,
-    pub totalDifficulty: candid::Nat,
+    pub totalDifficulty: Option<candid::Nat>,
     pub receiptsRoot: String,
     pub stateRoot: String,
     pub hash: String,
-    pub difficulty: candid::Nat,
+    pub difficulty: Option<candid::Nat>,
     pub size: candid::Nat,
     pub uncles: Vec<String>,
-    pub baseFeePerGas: candid::Nat,
+    // here
+    pub baseFeePerGas: Option<candid::Nat>,
     pub extraData: String,
     pub transactionsRoot: Option<String>,
     pub sha3Uncles: String,

--- a/packages/evm-rpc-canister-types/src/lib.rs
+++ b/packages/evm-rpc-canister-types/src/lib.rs
@@ -185,7 +185,6 @@ pub struct Block {
     pub difficulty: Option<candid::Nat>,
     pub size: candid::Nat,
     pub uncles: Vec<String>,
-    // here
     pub baseFeePerGas: Option<candid::Nat>,
     pub extraData: String,
     pub transactionsRoot: Option<String>,


### PR DESCRIPTION
my canister failed to load the current block number because the `Block` type contained some fields that caused trouble:
- difficulty -> was contained in response, but raised error anyway
- totalDifficulty -> was not contained in response
- baseFeePerGas -> was contained in response, but raised error anyway

Marking them optional resolved the issue.

The errors looked like this:
`[116870. 2024-10-27T06:07:41.440086079Z]: [TRAP]: Panicked at 'Call failed (update_last_observed_block_number): (CanisterError, "failed to decode canister response as (evm_rpc_canister_types::MultiGetBlockByNumberResult,): Fail to decode argument 0")', canisters/chain_fusion/src/logs.rs:172:10`